### PR TITLE
0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes to CSS Typed Object Model
 
+### 0.3.0 (April 17, 2018)
+
+- Only polyfill constructors on the window object passed into `polyfill()`
+- Support CSS calc, like `add()`, `sub()`, `mul()`, and `div()`
+- Support CSS min and max, like `min()` and `max()`
+
 ### 0.2.0 (April 4, 2018)
 
 - Safely checks for existing methods before polyfilling

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ Use [CSS Typed Object Model] features:
 ```js
 // Element styles
 document.body.attributeStyleMap.set('padding-top', CSS.px(42));
-document.body.attributeStyleMap.get('padding-top') // CSSUnitValue { value: 42, unit: 'px' }
+document.body.attributeStyleMap.get('padding-top') /* CSSUnitValue {
+  value: 42,
+  unit: 'px'
+}.toString() => 42px */
 
 document.body.attributeStyleMap.set('opacity', 0.3);
 typeof document.body.attributeStyleMap.get('opacity').value // number
@@ -34,7 +37,71 @@ document.body.attributeStyleMap.get('opacity').unit // "number"
 
 // Stylesheet rules
 document.styleSheets[0].cssRules[0].styleMap.set('padding-top', '100px');
-document.styleSheets[0].cssRules[0].styleMap.get('padding-top'); // CSSUnitValue { value: 100, unit: 'px' }
+document.styleSheets[0].cssRules[0].styleMap.get('padding-top'); /* CSSUnitValue {
+  value: 100,
+  unit: 'px'
+}.toString() => 100px */
+
+// Math products
+CSS.px(15).add(CSS.rem(10), CSS.em(5)) /* CSSMathSum {
+  operator: "sum",
+  values: [
+    CSSUnitValue { value: 15, unit: 'px' },
+    CSSUnitValue { value: 10, unit: 'rem' },
+    CSSUnitValu { value: 5, unit: 'em' }
+  ]
+}.toString() => calc(15px + 10rem + 5em) */
+
+CSS.px(15).mul(CSS.rem(10), CSS.em(5)) /* CSSMathProduct {
+  operator: "product",
+  values: [
+    CSSUnitValue { value: 15, unit: 'px' },
+    CSSUnitValue { value: 10, unit: 'rem' },
+    CSSUnitValu { value: 5, unit: 'em' }
+  ]
+}.toString() => calc(15px * 10rem * 5em) */
+
+CSS.px(15).sub(CSS.rem(10), CSS.em(5)) /* CSSMathSum {
+  operator: "sum",
+  values: [
+    CSSUnitValue { value: 15, unit: 'px' },
+    CSSUnitValue { value: -10, unit: 'rem' },
+    CSSUnitValu { value: -5, unit: 'em' }
+  ]
+}.toString() => calc(15px + -10rem + -5em) */
+
+CSS.px(15).div(CSS.rem(10), CSS.em(5)) /* CSSMathProduct {
+  operator: "product",
+  values: [
+    CSSUnitValue { value: 15, unit: 'px' },
+    CSSMathInvert {
+      operator: 'invert',
+      value: CSSUnitValue { value: 10, unit: 'rem' }
+    },
+    CSSMathInvert {
+      operator: 'invert',
+      value: CSSUnitValue { value: 5, unit: 'em' }
+    }
+  ]
+}.toString() => calc(15px / 10rem / 5em) */
+
+CSS.px(15).max(CSS.rem(10), CSS.em(5)) /* CSSMathMax {
+  operator: 'max',
+  values: [
+    CSSUnitValue { value: 15, unit: 'px' },
+    CSSUnitValue { value: 10, unit: 'rem' },
+    CSSUnitValu { value: 5, unit: 'em' }
+  ],
+}.toString() => max(15px, 10rem, 5em) */
+
+CSS.px(15).min(CSS.rem(10), CSS.em(5)) /* CSSMathMin {
+  operator: 'min',
+  values: [
+    CSSUnitValue { value: 15, unit: 'px' },
+    CSSUnitValue { value: 10, unit: 'rem' },
+    CSSUnitValu { value: 5, unit: 'em' }
+  ],
+}.toString() => min(15px, 10rem, 5em) */
 ```
 
 ## Features
@@ -45,13 +112,17 @@ The `polyfill` function adds the following functions to `window` if they do not
 already exist:
 
 - `CSS`
-- `CSSStyleValue`
 - `CSSKeywordValue`
+- `CSSMathInvert`
+- `CSSMathMax`
+- `CSSMathMin`
+- `CSSMathProduct`
+- `CSSMathSum`
+- `CSSStyleValue`
 - `CSSUnitValue`
 - `StylePropertyMap`
 
-It also adds the following functions to `window.CSS` if they do not already
-exist:
+It then adds the following functions to `CSS` if they do not already exist:
 
 - `number`
 - `percent`
@@ -83,39 +154,20 @@ exist:
 - `dppx`
 - `fr`
 
-### StylePropertyMap
+The new `CSSUnitValue` instances returned by these methods extend
+`CSSNumericValue`, which allow them to use the following methods:
 
-A constructor for `StylePropertyMap`, used by the polyfill for `CSS`,
-`CSSRule`, and `Element`.
+- `add`
+- `div`
+- `max`
+- `min`
+- `mul`
+- `sub`
 
-```js
-import { StylePropertyMap } from 'css-typed-om';
-```
+The result of these transforms may be a new `CSSUnitValue` instance or a new
+`CSSMathProduct`, `CSSMathMax`, `CSSMathMin`, or `CSSMathSum` instance.
 
-### CSSKeywordValue
-
-A constructor for `CSSKeywordValue`, used by `StylePropertyMap`.
-
-```js
-import { CSSKeywordValue } from 'css-typed-om';
-```
-
-### CSSUnitValue
-
-A constructor for `CSSUnitValue`, used by `StylePropertyMap`.
-
-```js
-import { CSSUnitValue } from 'css-typed-om';
-```
-
-### CSSStyleValue
-
-A constructor for `CSSStyleValue`, the super constructor of `CSSKeywordValue`
-and `CSSStyleValue`.
-
-```js
-import { StylePropertyMap } from 'css-typed-om';
-```
+They all stringify back into compliant CSS.
 
 [npm-url]: https://www.npmjs.com/package/css-typed-om
 [npm-img]: https://img.shields.io/npm/v/css-typed-om.svg

--- a/lib/CSSMathInvert.js
+++ b/lib/CSSMathInvert.js
@@ -1,0 +1,19 @@
+const _value = new WeakMap();
+
+export default class CSSMathInvert {
+	get operator() {
+		return 'invert';
+	}
+
+	get value() {
+		return _value.get(this);
+	}
+
+	toString() {
+		return `calc(1 / ${_value.get(this)})`
+	}
+
+	constructor(value) {
+		_value.set(this, value)
+	}
+}

--- a/lib/CSSMathMax.js
+++ b/lib/CSSMathMax.js
@@ -1,0 +1,19 @@
+const _values = new WeakMap();
+
+export default class CSSMathMax {
+	get operator() {
+		return 'max';
+	}
+
+	get values() {
+		return _values.get(this);
+	}
+
+	toString() {
+		return `max(${_values.get(this).join(', ')})`
+	}
+
+	constructor(...values) {
+		_values.set(this, values);
+	}
+}

--- a/lib/CSSMathMin.js
+++ b/lib/CSSMathMin.js
@@ -1,0 +1,19 @@
+const _values = new WeakMap();
+
+export default class CSSMathMin {
+	get operator() {
+		return 'min';
+	}
+
+	get values() {
+		return _values.get(this);
+	}
+
+	toString() {
+		return `min(${_values.get(this).join(', ')})`
+	}
+
+	constructor(...values) {
+		_values.set(this, values);
+	}
+}

--- a/lib/CSSMathProduct.js
+++ b/lib/CSSMathProduct.js
@@ -1,0 +1,32 @@
+import CSSMathInvert from './CSSMathInvert'
+
+const _values = new WeakMap();
+
+export default class CSSMathProduct {
+	get operator() {
+		return 'product';
+	}
+
+	get values() {
+		return _values.get(this);
+	}
+
+	toString() {
+		return `calc(${_values.get(this).reduce(
+			(contents, value) => `${value instanceof CSSMathInvert
+				? `${contents
+						? `${contents} / `
+					: '1 / '
+				}${value.value}`
+			: `${contents
+					? `${contents} * `
+				: ''}${value}`
+			}`,
+			''
+		)})`
+	}
+
+	constructor(...values) {
+		_values.set(this, values);
+	}
+}

--- a/lib/CSSMathSum.js
+++ b/lib/CSSMathSum.js
@@ -1,0 +1,22 @@
+const _values = new WeakMap();
+
+export default class CSSMathSum {
+	get operator() {
+		return 'product';
+	}
+
+	get values() {
+		return _values.get(this);
+	}
+
+	toString() {
+		return `calc(${_values.get(this).reduce(
+			(contents, value) => `${contents ? `${contents} + ` : ''}${value}`,
+			''
+		)})`
+	}
+
+	constructor(...values) {
+		_values.set(this, values);
+	}
+}

--- a/lib/CSSNumericArray.js
+++ b/lib/CSSNumericArray.js
@@ -1,0 +1,1 @@
+export default class CSSNumericArray extends Array {}

--- a/lib/CSSNumericArray.js
+++ b/lib/CSSNumericArray.js
@@ -1,1 +1,0 @@
-export default class CSSNumericArray extends Array {}

--- a/lib/CSSNumericValue.js
+++ b/lib/CSSNumericValue.js
@@ -1,0 +1,135 @@
+import CSSMathMax from './CSSMathMax'
+import CSSMathMin from './CSSMathMin'
+import CSSUnitValue from './CSSUnitValue';
+import CSSMathProduct from './CSSMathProduct'
+import CSSMathInvert from './CSSMathInvert'
+import CSSMathSum from './CSSMathSum'
+
+export default class CSSNumericValue {
+	add(...args) {
+		const Constructor = this.constructor
+		const result = new Constructor(this.value, this.unit)
+		const values = []
+
+		for (let arg of args) {
+			if (arg instanceof Constructor) {
+				if (values.length || result.unit !== arg.unit) {
+					values.push(arg)
+				} else {
+					result.value -= arg.value
+				}
+			} else if (
+				arg instanceof CSSMathProduct ||
+				arg instanceof CSSMathMax ||
+				arg instanceof CSSMathMin ||
+				arg instanceof CSSMathInvert
+			 ) {
+				values.push(arg)
+			} else {
+				return null
+			}
+		}
+
+		return values.length ? new CSSMathSum(result, ...values) : result
+	}
+
+	div(...args) {
+		const Constructor = this.constructor
+		const result = new Constructor(this.value, this.unit)
+		const values = []
+
+		for (let arg of args) {
+			if (arg instanceof Constructor) {
+				if (values.length || result.unit !== arg.unit && arg.unit !== 'number') {
+					values.push(arg)
+				} else {
+					result.value /= arg.value
+				}
+			} else {
+				return null
+			}
+		}
+
+		return values.length ? new CSSMathProduct(result, ...values.map(
+			value => new CSSMathInvert(value)
+		)) : result
+	}
+
+	max(...args) {
+		const result = new CSSUnitValue(this.value, this.unit)
+		const values = [result]
+
+		for (let arg of args) {
+			if (arg instanceof CSSUnitValue) {
+				if (values.length > 1 || result.unit !== arg.unit) {
+					values.push(arg)
+				} else {
+					result.value = Math.max(result.value, arg.value)
+				}
+			} else {
+				return null
+			}
+		}
+
+		return values.length > 1 ? new CSSMathMax(values) : result
+	}
+
+	min(...args) {
+		const result = new CSSUnitValue(this.value, this.unit)
+		const values = [result]
+
+		for (let arg of args) {
+			if (arg instanceof CSSUnitValue) {
+				if (values.length > 1 || result.unit !== arg.unit) {
+					values.push(arg)
+				} else {
+					result.value = Math.min(result.value, arg.value)
+				}
+			} else {
+				return null
+			}
+		}
+
+		return values.length > 1 ? new CSSMathMin(...values) : result
+	}
+
+	mul(...args) {
+		const Constructor = this.constructor
+		const result = new Constructor(this.value, this.unit)
+		const values = []
+
+		for (let arg of args) {
+			if (arg instanceof Constructor) {
+				if (values.length || result.unit !== arg.unit && arg.unit !== 'number') {
+					values.push(arg)
+				} else {
+					result.value *= arg.value
+				}
+			} else {
+				return null
+			}
+		}
+
+		return values.length ? new CSSMathProduct(result, ...values) : result
+	}
+
+	sub(...args) {
+		const Constructor = this.constructor
+		const result = new Constructor(this.value, this.unit)
+		const values = []
+
+		for (let arg of args) {
+			if (arg instanceof Constructor) {
+				if (values.length || result.unit !== arg.unit) {
+					values.push(new Constructor(arg.value * -1, arg.unit))
+				} else {
+					result.value -= arg.value
+				}
+			} else {
+				return null
+			}
+		}
+
+		return values.length ? new CSSMathSum(result, ...values) : result
+	}
+}

--- a/lib/CSSNumericValue.js
+++ b/lib/CSSNumericValue.js
@@ -71,7 +71,7 @@ export default class CSSNumericValue {
 			}
 		}
 
-		return values.length > 1 ? new CSSMathMax(values) : result
+		return values.length > 1 ? new CSSMathMax(...values) : result
 	}
 
 	min(...args) {

--- a/lib/CSSUnitValue.js
+++ b/lib/CSSUnitValue.js
@@ -1,9 +1,10 @@
 import units from './units';
+import CSSNumericValue from './CSSNumericValue'
 
 const _value = new WeakMap();
 const _unit = new WeakMap();
 
-export default class CSSUnitValue {
+export default class CSSUnitValue extends CSSNumericValue {
 	get value() {
 		return _value.get(this);
 	}
@@ -21,6 +22,8 @@ export default class CSSUnitValue {
 	}
 
 	constructor(...args) {
+		super()
+
 		if (args.length < 2) {
 			throw new TypeError(`Failed to construct 'CSSUnitValue': 2 arguments required, but only ${args.length} present.`);
 		}

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,6 +1,11 @@
 import CSSKeywordValue from './CSSKeywordValue';
-import CSSUnitValue from './CSSUnitValue';
+import CSSMathInvert from './CSSMathInvert';
+import CSSMathMax from './CSSMathMax';
+import CSSMathMin from './CSSMathMin';
+import CSSMathProduct from './CSSMathProduct';
+import CSSMathSum from './CSSMathSum';
 import CSSStyleValue from './CSSStyleValue';
+import CSSUnitValue from './CSSUnitValue';
 import StylePropertyMap from './StylePropertyMap';
 import units from './units';
 
@@ -34,8 +39,13 @@ export default function polyfill(window) {
 	);
 
 	if (!window.CSSKeywordValue) window.CSSKeywordValue = CSSKeywordValue;
-	if (!window.CSSUnitValue) window.CSSUnitValue = CSSUnitValue;
+	if (!window.CSSMathInvert) window.CSSMathInvert = CSSMathInvert;
+	if (!window.CSSMathMax) window.CSSMathMax = CSSMathMax;
+	if (!window.CSSMathMin) window.CSSMathMin = CSSMathMin;
+	if (!window.CSSMathProduct) window.CSSMathProduct = CSSMathProduct;
+	if (!window.CSSMathSum) window.CSSMathSum = CSSMathSum;
 	if (!window.CSSStyleValue) window.CSSStyleValue = CSSStyleValue;
+	if (!window.CSSUnitValue) window.CSSUnitValue = CSSUnitValue;
 	if (!window.StylePropertyMap) window.StylePropertyMap = StylePropertyMap;
 
 	function defineProperty(prototype, property, getStyle) {

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -16,19 +16,19 @@ export default function polyfill(window) {
 	);
 
 	defineProperty(
-		CSSRule.prototype,
+		window.CSSRule.prototype,
 		'styleMap',
 		context => context.style
 	);
 
 	defineProperty(
-		Element.prototype,
+		window.Element.prototype,
 		'attributeStyleMap',
 		context => context.style
 	);
 
 	defineProperty(
-		Element.prototype,
+		window.Element.prototype,
 		'computedStyleMap',
 		context => getComputedStyle(context)
 	);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-typed-om",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Use CSS Typed Object Model in the browser",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "license": "CC0-1.0",
@@ -25,13 +25,13 @@
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.2.2",
+    "babel-eslint": "^8.2.3",
     "babel-plugin-array-includes": "^2.0.3",
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.19.1",
     "eslint-config-dev": "^2.0.0",
     "pre-commit": "^1.2.2",
-    "rollup": "^0.57.1",
+    "rollup": "^0.58.0",
     "rollup-plugin-babel": "^3.0.3"
   },
   "eslintConfig": {


### PR DESCRIPTION
- Only polyfills constructors on the window object passed into `polyfill(window)`
- Support CSS calc, like `add()`, `sub()`, `mul()`, and `div()`
- Support CSS min and max, like `min()` and `max()`